### PR TITLE
Refactor manylinux tag logic

### DIFF
--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -1,14 +1,17 @@
+import logging
 import re
 import sys
+import warnings
 
 from pathlib import Path
 from posixpath import expandvars
-from typing import TYPE_CHECKING, Dict, List, Optional
-from urllib.parse import urldefrag, urlparse, urlsplit, urlunsplit
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple
+from urllib.parse import urldefrag, urlsplit, urlunsplit
 
 from clikit.api.io.flags import VERY_VERBOSE
 from clikit.io import ConsoleIO, NullIO
 from packaging.tags import compatible_tags, cpython_tags, mac_platforms
+from packaging.version import Version
 
 from conda_lock.interfaces.vendored_poetry import (
     Chooser,
@@ -39,6 +42,7 @@ from conda_lock.models.pip_repository import PipRepository
 if TYPE_CHECKING:
     from packaging.tags import Tag
 
+logger = logging.getLogger(__name__)
 
 # NB: in principle these depend on the glibc on the machine creating the conda env.
 # We use tags supported by manylinux Docker images, which are likely the most common
@@ -55,6 +59,12 @@ class PlatformEnv(Env):
     Fake poetry Env to match PyPI distributions to the target conda environment
     """
 
+    _sys_platform: Literal["darwin", "linux", "win32"]
+    _platform_system: Literal["Darwin", "Linux", "Windows"]
+    _os_name: Literal["posix", "nt"]
+    _platforms: List[str]
+    _python_version: Tuple[int, ...]
+
     def __init__(
         self,
         python_version: str,
@@ -67,33 +77,12 @@ class PlatformEnv(Env):
             arch = "x86_64"
 
         if system == "linux":
-            # We use MANYLINUX_TAGS but only go up to the latest supported version
-            # as provided by __glibc if present
-            self._platforms = []
-            if platform_virtual_packages:
-                # Get the glibc_version from virtual packages, falling back to
-                # the last of MANYLINUX_TAGS when absent
-                glibc_version = MANYLINUX_TAGS[-1]
-                for p in platform_virtual_packages.values():
-                    if p["name"] == "__glibc":
-                        glibc_version = p["version"]
-                glibc_version_splits = list(map(int, glibc_version.split(".")))
-                for tag in MANYLINUX_TAGS:
-                    if tag[0] == "_":
-                        # Compare to see if glibc_version is greater than this version
-                        if list(map(int, tag[1:].split("_"))) > glibc_version_splits:
-                            break
-                    self._platforms.append(f"manylinux{tag}_{arch}")
-                    if tag == glibc_version:  # Catches 1 and 2010 case
-                        # We go no further than the maximum specific GLIBC version
-                        break
-                # Latest tag is most preferred so list first
-                self._platforms.reverse()
-            else:
-                self._platforms = [
-                    f"manylinux{tag}_{arch}" for tag in reversed(MANYLINUX_TAGS)
-                ]
-            self._platforms.append(f"linux_{arch}")
+            compatible_manylinux_tags = _compute_compatible_manylinux_tags(
+                platform_virtual_packages=platform_virtual_packages
+            )
+            self._platforms = [
+                f"manylinux{tag}_{arch}" for tag in compatible_manylinux_tags
+            ] + [f"linux_{arch}"]
         elif system == "osx":
             self._platforms = list(mac_platforms(MACOS_VERSION, arch))
         elif platform == "win-64":
@@ -138,6 +127,110 @@ class PlatformEnv(Env):
             "platform_system": self._platform_system,
             "os_name": self._os_name,
         }
+
+
+def _extract_glibc_version_from_virtual_packages(
+    platform_virtual_packages: Dict[str, dict]
+) -> Optional[Version]:
+    """Get the glibc version from the "package" repodata of a chosen platform.
+
+    >>> platform_virtual_packages = {
+    ...     "__glibc-2.17-0.tar.bz2": {
+    ...         "name": "__glibc",
+    ...         "version": "2.17",
+    ...     },
+    ... }
+    >>> _extract_glibc_version_from_virtual_packages(platform_virtual_packages)
+    <Version('2.17')>
+    >>> _extract_glibc_version_from_virtual_packages({}) is None
+    True
+    """
+    matches: List[Version] = []
+    for p in platform_virtual_packages.values():
+        if p["name"] == "__glibc":
+            matches.append(Version(p["version"]))
+    if len(matches) == 0:
+        return None
+    elif len(matches) == 1:
+        return matches[0]
+    else:
+        lowest = min(matches)
+        warnings.warn(
+            f"Multiple __glibc virtual package entries found! "
+            f"{matches=} Using the lowest version {lowest}."
+        )
+        return lowest
+
+
+def _glibc_version_from_manylinux_tag(tag: str) -> Version:
+    """
+    Return the glibc version for the given manylinux tag
+
+    >>> _glibc_version_from_manylinux_tag("2010")
+    <Version('2.12')>
+    >>> _glibc_version_from_manylinux_tag("_2_28")
+    <Version('2.28')>
+    """
+    SPECIAL_CASES = {
+        "1": Version("2.5"),
+        "2010": Version("2.12"),
+        "2014": Version("2.17"),
+    }
+    if tag in SPECIAL_CASES:
+        return SPECIAL_CASES[tag]
+    elif tag.startswith("_"):
+        return Version(tag[1:].replace("_", "."))
+    else:
+        raise ValueError(f"Unknown manylinux tag {tag}")
+
+
+def _compute_compatible_manylinux_tags(
+    platform_virtual_packages: Optional[Dict[str, dict]]
+) -> List[str]:
+    """Determine the manylinux tags that are compatible with the given platform.
+
+    If there is no glibc virtual package, then assume that all manylinux tags are
+    compatible.
+
+    The result is sorted in descending order in order to favor the latest.
+
+    >>> platform_virtual_packages = {
+    ...     "__glibc-2.24-0.tar.bz2": {
+    ...         "name": "__glibc",
+    ...         "version": "2.24",
+    ...     },
+    ... }
+    >>> _compute_compatible_manylinux_tags({}) == list(reversed(MANYLINUX_TAGS))
+    True
+    >>> _compute_compatible_manylinux_tags(platform_virtual_packages)
+    ['_2_24', '_2_17', '2014', '2010', '1']
+    """
+    # We use MANYLINUX_TAGS but only go up to the latest supported version
+    # as provided by __glibc if present
+
+    latest_supported_glibc_version: Optional[Version] = None
+    # Try to get the glibc version from the virtual packages if it exists
+    if platform_virtual_packages:
+        latest_supported_glibc_version = _extract_glibc_version_from_virtual_packages(
+            platform_virtual_packages
+        )
+    # Fall back to the latest of MANYLINUX_TAGS
+    if latest_supported_glibc_version is None:
+        latest_supported_glibc_version = _glibc_version_from_manylinux_tag(
+            MANYLINUX_TAGS[-1]
+        )
+
+    # The glibc versions are backwards compatible, so filter the MANYLINUX_TAGS
+    # to those compatible with less than or equal to the latest supported
+    # glibc version.
+    # Note that MANYLINUX_TAGS is sorted in ascending order. The latest tag
+    # is most preferred so we reverse the order.
+    compatible_manylinux_tags = [
+        tag
+        for tag in reversed(MANYLINUX_TAGS)
+        if _glibc_version_from_manylinux_tag(tag) <= latest_supported_glibc_version
+    ]
+    return compatible_manylinux_tags
 
 
 REQUIREMENT_PATTERN = re.compile(

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -131,6 +131,11 @@ def _extract_glibc_version_from_virtual_packages(
 ) -> Optional[Version]:
     """Get the glibc version from the "package" repodata of a chosen platform.
 
+    Note that the glibc version coming from a virtual package is never a legacy
+    manylinux tag (i.e. 1, 2010, or 2014). Those tags predate PEP 600 which
+    introduced manylinux tags containing the glibc version. Currently, all
+    relevant glibc versions look like 2.XX.
+
     >>> platform_virtual_packages = {
     ...     "__glibc-2.17-0.tar.bz2": {
     ...         "name": "__glibc",

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import sys
 import warnings
@@ -41,8 +40,6 @@ from conda_lock.models.pip_repository import PipRepository
 
 if TYPE_CHECKING:
     from packaging.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 # NB: in principle these depend on the glibc on the machine creating the conda env.
 # We use tags supported by manylinux Docker images, which are likely the most common

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-vrsx -n auto"
+addopts = "--doctest-modules -vrsx -n auto"
 flake8-max-line-length = 105
 flake8-ignore = ["docs/* ALL", "conda_lock/_version.py ALL"]
 filterwarnings = "ignore::DeprecationWarning"


### PR DESCRIPTION
I was struggling to follow the previous logic, so I read the [manylinux PEP](https://peps.python.org/pep-0600/)s and decided to refactor.

I wanted to make sure we were covering all possible edge cases.

Also, I agree that using `packaging.version.Version` is overkill here, but throughout `conda-lock` we're parsing versions all over the place, and so things get a bit crazy if locally we're constantly reimplementing string-parsing logic. And indeed, I uncovered that the previous commit was mixing `_` and `.` separators:

```python
In [1]: from conda_lock.pypi_solver import PlatformEnv

In [2]: e = PlatformEnv("3.12", "linux-64", {"x": {"name": "not_glibc"}})
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[2], line 1
----> 1 e = PlatformEnv("3.12", "linux-64", {"x": {"name": "not_glibc"}})

File ~/repos/conda-lock/conda_lock/pypi_solver.py:80, in PlatformEnv.__init__(self, python_version, platform, platform_virtual_packages)
     78     if p["name"] == "__glibc":
     79         glibc_version = p["version"]
---> 80 glibc_version_splits = list(map(int, glibc_version.split(".")))
     81 for tag in MANYLINUX_TAGS:
     82     if tag[0] == "_":
     83         # Compare to see if glibc_version is greater than this version

ValueError: invalid literal for int() with base 10: '_2_28'
```

Does this refactor look clear and correct? (Feel free to skip looking at the new test I wrote; it's pretty tedious.) Thanks!!